### PR TITLE
Add css rule to set the top margin for all media class descendants of the ptb cla...

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -94,6 +94,7 @@ body {
 .mtb {margin-top: 50px; margin-bottom: 50px;}
 .mtb2 { margin-top: 100px; margin-bottom: 100px;}
 .ptb {padding-top: 60px; padding-bottom: 60px;}
+.ptb .media { margin-top: 15px;}
 
 .clear {
 	clear: both;


### PR DESCRIPTION
...ss to be 15px so that the pictures all line up vertically. Bootstrap was setting the first media child's top margin to 0px causing alignment issues with the first image of each row.